### PR TITLE
AWS Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+# Enviornment Variables
+.env
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
 *tfstate*
+
+# Terraform variables
 *tfvars*
-.terraform/
+
+# Crash log files
+crash.log
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,46 @@
+#########################
+# Cluster Instances
+#########################
+
+resource "aws_instance" "etcd" {
+  count         = 3
+  ami           = "ami-1967056a" // Unbuntu 16.04 LTS HVM, EBS-SSD
+  instance_type = "t2.micro"
+
+  subnet_id                   = aws_subnet.kubernetes.id
+  private_ip                  = cidrhost("10.43.0.0/16", 10 + count.index)
+  associate_public_ip_address = true
+
+  availability_zone      = "us-east-1"
+  vpc_security_group_ids = [aws_security_group.kubernetes.id]
+  key_name               = "my-keypair"
+}
+
+resource "aws_instance" "controller" {
+  count         = 3
+  ami           = "ami-1967056a" // Unbuntu 16.04 LTS HVM, EBS-SSD
+  instance_type = "t2.micro"
+
+  subnet_id                   = aws_subnet.kubernetes.id
+  private_ip                  = cidrhost("10.43.0.0/16", 10 + count.index)
+  associate_public_ip_address = true
+
+  availability_zone      = "us-east-1"
+  vpc_security_group_ids = [aws_security_group.kubernetes.id]
+  key_name               = "my-keypair"
+}
+
+resource "aws_instance" "worker" {
+  count         = 3
+  ami           = "ami-1967056a" // Unbuntu 16.04 LTS HVM, EBS-SSD
+  instance_type = "t2.micro"
+
+  subnet_id                   = aws_subnet.kubernetes.id
+  private_ip                  = cidrhost("10.43.0.0/16", 10 + count.index)
+  associate_public_ip_address = true
+
+  availability_zone      = "us-east-1"
+  vpc_security_group_ids = [aws_security_group.kubernetes.id]
+  key_name               = "my-keypair"
+  source_dest_check      = false
+}

--- a/elb.tf
+++ b/elb.tf
@@ -1,0 +1,27 @@
+################
+# Load Balancer
+################
+
+resource "aws_elb" "kubernetes_api" {
+  name                      = "kube-api"
+  instances                 = [join("\",\"", aws_instance.controller.*.id)]
+  subnets                   = [aws_subnet.kubernetes.id]
+  cross_zone_load_balancing = false
+
+  security_groups = [aws_security_group.kubernetes_api.id]
+
+  listener {
+    lb_port           = 6443
+    instance_port     = 6443
+    lb_protocol       = "TCP"
+    instance_protocol = "TCP"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 15
+    target              = "HTTP:8080/healthz"
+    interval            = 30
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,34 @@
+#########################
+#IAM Role for Kubernetes
+#########################
+
+resource "aws_iam_role" "kubernetes" {
+  name               = "kubernetes"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [ { "Effect": "Allow", "Principal": { "Service": "ec2.amazonaws.com" }, "Action": "sts:AssumeRole" } ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "kubernetes" {
+  name   = "kubernetes"
+  role   = aws_iam_role.kubernetes.id
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Action" : ["ec2:*"], "Effect": "Allow", "Resource": ["*"] },
+    { "Action" : ["elasticloadbalancing:*"], "Effect": "Allow", "Resource": ["*"] },
+    { "Action": "route53:*", "Effect": "Allow",  "Resource": ["*"] },
+    { "Action": "ecr:*", "Effect": "Allow", "Resource": "*" }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "kubernetes" {
+  name = "kubernetes"
+  role = aws_iam_role.kubernetes.name
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,18 @@
+###################
+# AWS Configuration
+###################
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.70"
+    }
+  }
+}
+
+# Define AWS as our provider
+provider "aws" {
+  profile = "default"
+  region  = "us-east-1"
+}

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,0 +1,61 @@
+##################
+# Security Groups
+#################
+
+resource "aws_security_group" "kubernetes" {
+  vpc_id = aws_vpc.kubernetes.id
+  name   = "kubernetes"
+
+  # Allow all outbound
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow all internal
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  # Allow all traffic from the API ELB
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = [aws_security_group.kubernetes_api.id]
+  }
+
+  # Allow all traffic from control host IP
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "kubernetes_api" {
+  vpc_id = aws_vpc.kubernetes.id
+  name   = "kubernetes-api"
+
+  # Allow inbound traffic to the port used by Kubernetes API HTTPS
+  ingress {
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow all outbound traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,35 @@
+#############################
+# Create VPC for Kubernetes
+#############################
+
+resource "aws_vpc" "kubernetes" {
+  cidr_block           = "10.43.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "kubernetes" {
+  vpc_id            = aws_vpc.kubernetes.id
+  cidr_block        = "10.43.0.0/16"
+  availability_zone = "eu-west-1a"
+}
+
+##################
+# Create Routing
+##################
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.kubernetes.id
+}
+
+resource "aws_route_table" "kubernetes" {
+  vpc_id = aws_vpc.kubernetes.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+}
+
+resource "aws_route_table_association" "kubernetes" {
+  subnet_id      = aws_subnet.kubernetes.id
+  route_table_id = aws_route_table.kubernetes.id
+}


### PR DESCRIPTION
### Description
Kubernetes requires a set of machines to host the Kubernetes control plane and the worker nodes where containers are ultimately run. This PR will set up provisioning these resources. 

### Notes
- Kubernetes networking model assumes a flat network in which containers and nodes can communicate with each other. 
- I set up a virtual private cloud (VPC) that will host the Kubernetes cluster. Inside the VPC is a public subnet. The subnet holds:  
   - 3 EC2 instances for Kubernetes Control Plane: Controller Manager, Scheduler, API Server.
   - 3 EC2 instances for the etcd cluster.
   - 3 EC2 instances as Kubernetes workers 
### Architecture Diagram (so far...)
![K8Challenge](https://user-images.githubusercontent.com/7966507/96193865-25562880-0f17-11eb-8669-4d5a7afba2a6.png)

